### PR TITLE
add deploy workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -12,7 +12,7 @@ jobs:
   # see also:
   # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
   deploy:
-    if: startsWith(github.ref, 'refs/tags/') # only run this job on a tagged commit
+    if: startsWith(github.ref, 'refs/tags/') 
     name: Deploy
     runs-on: ubuntu-latest
 
@@ -26,22 +26,21 @@ jobs:
 
       - name: build wheel and sdist
         run: |
-          pip install -U pip build twine
+          python -m pip install build
           python -m build --sdist --wheel
 
-      # this just manually runs twine, but you could also use:
-      # https://github.com/pypa/gh-action-pypi-publish
-      - name: Build and publish
-        run: twine upload dist/*
-        env:
-          TWINE_USERNAME: __token__
+      - name: Publish distribution 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags') # only run this step on a tagged commit
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
           # this requires that you've created a https://pypi.org/help/#apitoken
-          # and added it to a secret in your repo named TWINE_API_KEY
+          # and added it to a secret in your repo named PYPI_API_TOKEN
           # https://docs.github.com/en/actions/security-guides/encrypted-secrets
-          TWINE_PASSWORD: ${{ secrets.TWINE_API_KEY }}
+          password: ${{ secrets.PYPI_API_TOKEN }}
 
       # this is optional ... it creates a github release in addition to a pypi release
       # https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository
       - uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags') # only run this step on a tagged commit
         with:
           generate_release_notes: true

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,47 @@
+name: Deploy to PyPI
+
+# this job will be triggered whenever you push to main, or push a tag
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+jobs:
+  # see also:
+  # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+  deploy:
+    if: startsWith(github.ref, 'refs/tags/') # only run this job on a tagged commit
+    name: Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: build wheel and sdist
+        run: |
+          pip install -U pip build twine
+          python -m build --sdist --wheel
+
+      # this just manually runs twine, but you could also use:
+      # https://github.com/pypa/gh-action-pypi-publish
+      - name: Build and publish
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          # this requires that you've created a https://pypi.org/help/#apitoken
+          # and added it to a secret in your repo named TWINE_API_KEY
+          # https://docs.github.com/en/actions/security-guides/encrypted-secrets
+          TWINE_PASSWORD: ${{ secrets.TWINE_API_KEY }}
+
+      # this is optional ... it creates a github release in addition to a pypi release
+      # https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository
+      - uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
as discussed, this adds a github workflow that would deploy to PyPI automatically on tagged commits:

1. make sure to update your version wherever it is specified (e.g. `setup.py`, etc...) and commit the change
2. tag the commit using an annotated tag:
    ```bash
    git tag -a v0.1.0 -m v0.1.0
    ```
3. push to github:
    ```bash
    git push --follow-tags
    ```

... and that will trigger this workflow
